### PR TITLE
Fix for messages not being deleted when exchange is recieved from Iron and then sent to another queue on Iron.

### DIFF
--- a/src/main/java/org/apache/camel/component/ironmq/IronMQComponent.java
+++ b/src/main/java/org/apache/camel/component/ironmq/IronMQComponent.java
@@ -49,7 +49,7 @@ public class IronMQComponent extends UriEndpointComponent {
             throw new IllegalArgumentException("Client or project and token must be specified.");
         }
 
-        Endpoint endpoint = new IronMQEndpoint(uri, this, ironMQConfiguration);
+        Endpoint endpoint = new IronMQEndpoint(uri + "://" + ironMQConfiguration.getQueueName(), this, ironMQConfiguration);
         ((ScheduledPollEndpoint)endpoint).setConsumerProperties(parameters);
 
         return endpoint;

--- a/src/main/java/org/apache/camel/component/ironmq/IronMQConsumer.java
+++ b/src/main/java/org/apache/camel/component/ironmq/IronMQConsumer.java
@@ -96,8 +96,11 @@ public class IronMQConsumer extends ScheduledBatchPollingConsumer {
 
             // add on completion to handle after work when the exchange is done
             exchange.addOnCompletion(new Synchronization() {
+
+                final String messageid = ExchangeHelper.getMandatoryHeader(exchange, IronMQConstants.MESSAGE_ID, String.class);
+
                 public void onComplete(Exchange exchange) {
-                    processCommit(exchange);
+                    processCommit(exchange, messageid);
                 }
 
                 public void onFailure(Exchange exchange) {
@@ -123,10 +126,9 @@ public class IronMQConsumer extends ScheduledBatchPollingConsumer {
      * 
      * @param exchange the exchange
      */
-    protected void processCommit(Exchange exchange) {
-        String messageid = null;
+    protected void processCommit(Exchange exchange, String messageid) {
         try {
-            messageid = ExchangeHelper.getMandatoryHeader(exchange, IronMQConstants.MESSAGE_ID, String.class);
+
             LOG.trace("Deleting message with id {}...", messageid);
             getEndpoint().getQueue().deleteMessage(messageid);
             LOG.trace("Message deleted");

--- a/src/test/java/org/apache/camel/component/ironmq/FromQueueToQueueTest.java
+++ b/src/test/java/org/apache/camel/component/ironmq/FromQueueToQueueTest.java
@@ -1,0 +1,91 @@
+package org.apache.camel.component.ironmq;
+
+import io.iron.ironmq.Client;
+import io.iron.ironmq.EmptyQueueException;
+import org.apache.camel.*;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by DKolb on 5/12/15.
+ */
+public class FromQueueToQueueTest extends CamelTestSupport {
+
+    @EndpointInject(uri = "mock:result")
+    private MockEndpoint result;
+
+    private IronMQEndpoint queue1;
+
+    private IronMQEndpoint queue2;
+
+
+    @Test
+    public void shouldDeleteMessageFromQueue1() throws Exception {
+
+        result.setExpectedMessageCount(1);
+
+        template.send("direct:start", ExchangePattern.InOnly, new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setBody("This is my message text.");
+            }
+        });
+
+        assertMockEndpointsSatisfied();
+
+        try {
+            queue1.getQueue().get();
+            fail("Message was in the first queue!");
+        } catch (IOException e) {
+            if(!(e instanceof EmptyQueueException)) {
+                // Unexpected exception.
+                throw e;
+            }
+        }
+
+        try {
+            queue2.getQueue().get();
+            fail("Message remained in second queue!");
+        } catch (IOException e) {
+            if(!(e instanceof EmptyQueueException)) {
+                // Unexpected exception.
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        IronMQComponent component = new IronMQComponent(context);
+        queue1 = generateEndpoint(component, "testqueue");
+        queue2 = generateEndpoint(component, "testqueue2");
+        context.addComponent("ironmq", component);
+        return context;
+    }
+
+    private IronMQEndpoint generateEndpoint(IronMQComponent component, String queueName) throws Exception {
+        Client mockClient = new IronMQClientMock("dummy", "dummy");
+        Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("client", mockClient);
+        IronMQEndpoint endpoint = (IronMQEndpoint)component.createEndpoint("ironmq", queueName, parameters);
+        return endpoint;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            public void configure() {
+                from("direct:start").to(queue1);
+                from(queue1).to(queue2);
+                from(queue2).to("mock:result");
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
A few things.  This arises because IronMQConsumer sets the MESSAGE_ID header on the exchange and then reads it back later when the onCompletion hooks are called.

However, if you route the exchange through an IronMQProducer (to("ironmq:blah")) then you'll end up with the MESSAGE_ID overwritten.

When constructing the test case, I also discovered that the way that URI's are assigned to endpoints, you could not consume from more than one iron.io queue because all endpoints end up with the same URI ("ironmq").  I modified this to take the form "ironmq://queueName", similar to how most other message-queue components handle multiple endpoints in the same component.

Let me know if this is useful to you.  We had some retry logic in a camel application that was working incorrectly because of the MESSAGE_ID overwrite when we sent malformed messages to an error queue in IronMQ, causing an endless message replication loop since it was never deleted off the queue.
